### PR TITLE
Fix relative paths for all environments

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,7 @@ History
 =======
 
 * New notes here
+* Fix relative paths for all environments
 
 1.0.1 (2016-10-28)
 ------------------

--- a/pip_lock.py
+++ b/pip_lock.py
@@ -45,10 +45,17 @@ def get_package_versions(lines):
     return versions
 
 
+def get_calling_frame_path():
+    for frame in inspect.stack():
+        file_name = os.path.abspath(frame[1])
+        if file_name != __file__:
+            return os.path.dirname(file_name)
+    raise Exception('Cannot find the parent frame.')
+
+
 def get_mismatches(requirements_file):
     """Return a dictionary of requirement mismatches."""
-    parent_frame_path = inspect.stack()[1][1]
-    requirements_path = os.path.join(os.path.dirname(parent_frame_path), requirements_file)
+    requirements_path = os.path.abspath(os.path.join(get_calling_frame_path(), requirements_file))
     pip_lines = read_pip(requirements_path)
 
     expected = get_package_versions(pip_lines)

--- a/tests/test_pip_lock.py
+++ b/tests/test_pip_lock.py
@@ -127,3 +127,8 @@ class TestCheckRequirements(object):
         _, err = capsys.readouterr()
         assert 'package1 has version 1.1 but you have version 1.0 installed' in err
         assert 'package2 is in requirements.txt but not in virtualenv' in err
+
+    @patch('pip_lock.pip_freeze')
+    def test_relative_requirements_file(self, pip_freeze):
+        pip_freeze.return_value = ['package==1.2']
+        check_requirements('test_requirements.txt')


### PR DESCRIPTION
Fix the `get_calling_frame_path` logic to get the first frame outside of `pip_lock`.