### PR TITLE
Some tidy up

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,8 @@ Pending release
 ---------------
 
 * New release notes go here
+* Fix 'mismatches' typo
+* Only indent mismatch list by 4 spaces in error message
 
 1.0.2 (2016-10-28)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Example usage
 
 
 At YPlan, we call ``check_requirements()`` within our Django ``manage.py`` which checks the requirements every time
-Django auto reloads or tests are run. We recommend checking the environment to ensure it is not run in production.
+Django starts or tests are run. We recommend checking the environment to ensure it is not run in production.
 
 API
 ===
@@ -66,19 +66,19 @@ Example:
 
     check_requirements(
         'requirements.txt',
-        post_text='\nRun the following on your host machine: \n\nYPLAN_REQS=1 vagrant provision\n'
+        post_text='\nRun the following on your host machine: \n\n    vagrant provision\n'
     )
 
 .. code-block:: bash
 
     There are requirement mismatches with requirements.txt:
-            * Package Django has version 1.9.10 but you have version 1.9.0 installed.
-            * Package requests has version 2.11.1 but you have version 2.11.0 installed.
-            * Package requests-oauthlib is in requirements.txt but not in virtualenv
+        * Package Django has version 1.9.10 but you have version 1.9.0 installed.
+        * Package requests has version 2.11.1 but you have version 2.11.0 installed.
+        * Package requests-oauthlib is in requirements.txt but not in virtualenv
 
     Run the following on your host machine:
 
-            YPLAN_REQS=1 vagrant provision
+        vagrant provision
 
 ``get_mismatches(requirements_file_path, post_text='')``
 --------------------------------------------------------

--- a/pip_lock.py
+++ b/pip_lock.py
@@ -79,7 +79,7 @@ def print_errors(errors, pre_text=None, post_text=None):
     if pre_text:
         sys.stderr.write(pre_text + "\n")
     for message in errors:
-        sys.stderr.write("        * {0}\n".format(message))
+        sys.stderr.write("    * {0}\n".format(message))
     if post_text:
         sys.stderr.write(post_text)
     sys.stderr.write("\033[0m")
@@ -106,7 +106,7 @@ def check_requirements(requirements_file, post_text=None):
 
         print_errors(
             errors,
-            "There are requirement mistmatches with {0}".format(requirements_file),
+            "There are requirement mismatches with {0}".format(requirements_file),
             post_text,
         )
         sys.exit(1)


### PR DESCRIPTION
* Fix a typo in the mismatches message
* Use only 4 spaces to indent the list of mismatches
* Use a non-YPlan-specific `vagrant provision` command in the message in the README