### PR TITLE
pip 10 support

### DIFF
--- a/pip_lock.py
+++ b/pip_lock.py
@@ -4,7 +4,11 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 import sys
 
-from pip.operations.freeze import freeze as pip_freeze
+# pip 10.0.0 made freezer internal. Try to use new name and fallback to old one.
+try:
+    from pip._internal.operations.freeze import freeze as pip_freeze
+except ImportError:
+    from pip.operations.freeze import freeze as pip_freeze
 
 __version__ = '1.1.0'
 

--- a/pip_lock.py
+++ b/pip_lock.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     from pip.operations.freeze import freeze as pip_freeze
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'
 
 
 def lines_from_file(filename):


### PR DESCRIPTION
The pip 10.0.0 broke interface, making freeze internal and as such, rendering pip-lock not working.

This changes attempt to load the new interface and fall back to old one. Tested with pip 10.0.0 and 9.0.3, tox returned no errors.